### PR TITLE
🛡️ Sentinel: Harden URL validation and article sanitization

### DIFF
--- a/src/components/ArticleReader.tsx
+++ b/src/components/ArticleReader.tsx
@@ -166,8 +166,32 @@ export function ArticleReader({ article, onClose, onNext, onPrev, hasNext, hasPr
     content = content.replace(/<div[^>]*>(\s|&nbsp;|<br\s*\/?>)*<\/div>/gi, '');
     content = content.replace(/<span[^>]*>(\s|&nbsp;|<br\s*\/?>)*<\/span>/gi, '');
     
-    return DOMPurify.sanitize(content, {
-      ADD_ATTR: ['style', 'allowfullscreen', 'frameborder', 'scrolling', 'controls', 'src', 'alt', 'width', 'height', 'srcset', 'sizes'],
+    // Create a local instance of DOMPurify to be thread-safe in React
+    const purifier = DOMPurify();
+
+    // Security enhancement: Add hooks to ensure all links and iframes are safe
+    purifier.addHook('afterSanitizeAttributes', (node) => {
+      // Force rel="nofollow noopener noreferrer" on all links
+      if (node.tagName === 'A') {
+        node.setAttribute('rel', 'nofollow noopener noreferrer');
+      }
+
+      // Force sandbox on iframes to prevent them from breaking the app
+      if (node.tagName === 'IFRAME') {
+        node.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-popups allow-forms');
+      }
+
+      // Sanitized protocols for src and href
+      if (node.hasAttribute('src')) {
+        node.setAttribute('src', getSafeUrl(node.getAttribute('src'), ''));
+      }
+      if (node.hasAttribute('href')) {
+        node.setAttribute('href', getSafeUrl(node.getAttribute('href'), ''));
+      }
+    });
+
+    return purifier.sanitize(content, {
+      ADD_ATTR: ['style', 'allowfullscreen', 'frameborder', 'scrolling', 'controls', 'src', 'alt', 'width', 'height', 'srcset', 'sizes', 'sandbox'],
       ADD_TAGS: ['video', 'audio', 'source', 'iframe', 'img'],
       FORBID_ATTR: ['id', 'name'],
     });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,13 +14,26 @@ export function isSafeUrl(url: string | null | undefined): boolean {
   const trimmed = url.trim();
   if (!trimmed) return false;
 
-  // Basic protocol check
-  const lowercase = trimmed.toLowerCase();
-  return (
-    lowercase.startsWith('http://') ||
-    lowercase.startsWith('https://') ||
-    lowercase.startsWith('mailto:')
-  );
+  // Allow protocol-relative URLs, relative paths, and anchors
+  if (
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../') ||
+    trimmed.startsWith('#')
+  ) {
+    return true;
+  }
+
+  try {
+    // Use the URL constructor for robust protocol validation
+    const parsed = new URL(trimmed);
+    return ['http:', 'https:', 'mailto:'].includes(parsed.protocol);
+  } catch (e) {
+    // If URL parsing fails and it's not a relative path we handle above,
+    // we return false to be safe.
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
🛡️ Sentinel: Harden URL validation and article sanitization

I have implemented several security enhancements to the article reading experience:

1. **Robust URL Validation**: Updated `src/lib/utils.ts` to use the native `URL` constructor for protocol validation. It now strictly allows only `http:`, `https:`, and `mailto:` protocols for absolute URLs, while explicitly permitting safe relative paths (`/`, `./`, `../`) and anchors (`#`).

2. **Defense-in-Depth Sanitization**: Enhanced the `DOMPurify` configuration in `src/components/ArticleReader.tsx`.
   - Switched to a local `DOMPurify` instance (`DOMPurify()`) to ensure thread-safety and prevent hook leakage across the application.
   - Added a `afterSanitizeAttributes` hook to automatically enforce security attributes:
     - All `<a>` tags now receive `rel="nofollow noopener noreferrer"`.
     - All `<iframe>` tags now receive a restrictive `sandbox` attribute.
     - All `src` and `href` attributes are passed through `getSafeUrl` for final protocol verification.

These changes provide multiple layers of protection against XSS, tab-nabbing, and malicious iframe behavior while maintaining full compatibility with legitimate feed content.

**Verification:**
- Validated `isSafeUrl` with a comprehensive test suite of 17 different URL patterns.
- Validated the sanitization logic with a runtime script using `jsdom` to confirm the presence of enforced attributes and the blocking of dangerous protocols.
- Verified that `pnpm lint` and `pnpm build` pass without errors.

---
*PR created automatically by Jules for task [11979131003611173162](https://jules.google.com/task/11979131003611173162) started by @malamoffo*