### PR TITLE
🎨 Palette: Enhance onboarding and modal accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Tactile Feedback & Accessibility Patterns]
 **Learning:** In mobile-first RSS readers, tactile feedback (e.g., scale-down on tap) significantly improves the perceived responsiveness of navigation controls. Accessibility is often overlooked in icon-heavy interfaces; every icon-only button must have an explicit `aria-label`, and the icons themselves should be hidden from screen readers to reduce noise.
 **Action:** Use `motion.button` with `whileTap={{ scale: 0.9 }}` for all primary navigation and action buttons. Always pair `aria-label` on buttons with `aria-hidden="true"` on their internal icons.
+
+## 2025-05-16 - [Onboarding Guidance & Modal Deep-linking]
+**Learning:** For apps with an empty initial state, a clear CTA that deep-links to the relevant configuration tab (e.g., Subscriptions) significantly reduces user friction.
+**Action:** Use an `initialTab` prop in modals to allow opening them to a specific context from CTA buttons. Pair with `aria-label` and `role="switch"` for accessibility.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { ArticleReader } from './components/ArticleReader';
 import { SettingsModal } from './components/SettingsModal';
 import { HeaderWidgets } from './components/HeaderWidgets';
 import { Article } from './types';
-import { RefreshCw, Rss, Inbox, Settings as SettingsIcon, CheckSquare, Search, X, LayoutGrid, Star } from 'lucide-react';
+import { RefreshCw, Rss, Inbox, Settings as SettingsIcon, CheckSquare, Search, X, LayoutGrid, Star, Plus } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from './lib/utils';
 
@@ -54,6 +54,7 @@ function MainContent() {
 
   const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<'settings' | 'subscriptions' | 'about' | undefined>(undefined);
   const [isMarkAllConfirmOpen, setIsMarkAllConfirmOpen] = useState(false);
   const [forceRefresh, setForceRefresh] = useState(0);
   const [filter, setFilter] = useState<'all' | 'unread' | 'favorites'>('unread');
@@ -417,11 +418,26 @@ function MainContent() {
           <div className="flex flex-col items-center justify-center h-64 text-gray-500 dark:text-gray-400 px-6 text-center">
             <Inbox className="w-16 h-16 mb-4 text-gray-300 dark:text-gray-600" />
             <p className="text-lg font-medium text-gray-900 dark:text-white mb-1">No articles found</p>
-            <p className="text-sm">
-              {feeds.length === 0 
-                ? "You haven't added any feeds yet. Open Settings to get started." 
-                : "You're all caught up!"}
-            </p>
+            <div className="text-sm">
+              {feeds.length === 0 ? (
+                <div className="space-y-4">
+                  <p>You haven't added any feeds yet.</p>
+                  <motion.button
+                    whileTap={{ scale: 0.95 }}
+                    onClick={() => {
+                      setSettingsInitialTab('subscriptions');
+                      setIsSettingsModalOpen(true);
+                    }}
+                    className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-bold shadow-lg shadow-indigo-500/20 transition-all"
+                  >
+                    <Plus className="w-5 h-5" aria-hidden="true" />
+                    Add your first feed
+                  </motion.button>
+                </div>
+              ) : (
+                <p>You're all caught up!</p>
+              )}
+            </div>
           </div>
         ) : (
           <div className="flex-1">
@@ -545,12 +561,17 @@ function MainContent() {
         )}
       </AnimatePresence>
 
-      <SettingsModal isOpen={isSettingsModalOpen} onClose={() => {
-        setIsSettingsModalOpen(false);
-        setFilter('all');
-        setSearchQuery('');
-        setIsSearchOpen(false);
-      }} />
+      <SettingsModal
+        isOpen={isSettingsModalOpen}
+        initialTab={settingsInitialTab}
+        onClose={() => {
+          setIsSettingsModalOpen(false);
+          setSettingsInitialTab(undefined);
+          setFilter('all');
+          setSearchQuery('');
+          setIsSearchOpen(false);
+        }}
+      />
       
       <AnimatePresence>
         {selectedArticle && (

--- a/src/components/AddFeedModal.tsx
+++ b/src/components/AddFeedModal.tsx
@@ -107,6 +107,7 @@ export function AddFeedModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
                   placeholder="https://example.com/feed.xml"
                   className="block w-full pl-10 pr-3 py-3 border border-gray-300 dark:border-gray-700 rounded-xl focus:ring-indigo-500 focus:border-indigo-500 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
                   required
+                  aria-label="Feed URL"
                 />
               </div>
               <motion.button

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -6,7 +6,15 @@ import { SwipeAction, Theme, ImageDisplay, FontSize } from '../types';
 import { AddFeedModal } from './AddFeedModal';
 import packageJson from '../../package.json';
 
-export function SettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+export function SettingsModal({
+  isOpen,
+  onClose,
+  initialTab
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  initialTab?: 'settings' | 'subscriptions' | 'about';
+}) {
   const { settings, updateSettings, feeds, removeFeed, updateFeed, progress, updateInfo, checkUpdates } = useRss();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
@@ -17,10 +25,10 @@ export function SettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: (
   
   React.useEffect(() => {
     if (isOpen) {
-      setActiveTab('settings');
+      setActiveTab(initialTab || 'settings');
       setSelectedFeedId(null);
     }
-  }, [isOpen]);
+  }, [isOpen, initialTab]);
 
   const handleThemeChange = (theme: Theme) => updateSettings({ theme });
   const handleImageDisplayChange = (imageDisplay: ImageDisplay) => updateSettings({ imageDisplay });
@@ -63,8 +71,12 @@ export function SettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: (
               <div className="flex justify-between items-center">
                 <div className="flex items-center gap-3">
                   {(activeTab !== 'settings' || selectedFeed) && (
-                    <button onClick={() => selectedFeed ? setSelectedFeedId(null) : setActiveTab('settings')} className="p-2 -ml-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
-                      <ArrowLeft className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+                    <button
+                      onClick={() => selectedFeed ? setSelectedFeedId(null) : setActiveTab('settings')}
+                      className="p-2 -ml-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                      aria-label="Go back"
+                    >
+                      <ArrowLeft className="w-5 h-5 text-gray-600 dark:text-gray-300" aria-hidden="true" />
                     </button>
                   )}
                   <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
@@ -73,8 +85,12 @@ export function SettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: (
                      activeTab === 'subscriptions' ? 'Subscriptions' : 'About Flusso'}
                   </h2>
                 </div>
-                <button onClick={() => selectedFeed ? setSelectedFeedId(null) : onClose()} className="p-2 bg-gray-100 dark:bg-gray-800 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
-                  <X className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+                <button
+                  onClick={() => selectedFeed ? setSelectedFeedId(null) : onClose()}
+                  className="p-2 bg-gray-100 dark:bg-gray-800 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                  aria-label="Close settings"
+                >
+                  <X className="w-5 h-5 text-gray-600 dark:text-gray-300" aria-hidden="true" />
                 </button>
               </div>
             </div>
@@ -164,6 +180,9 @@ export function SettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: (
                       <button 
                         onClick={() => updateSettings({ pureBlack: !settings.pureBlack })}
                         className={`w-12 h-6 rounded-full transition-colors relative ${settings.pureBlack ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'}`}
+                        role="switch"
+                        aria-checked={settings.pureBlack}
+                        aria-label="Toggle Pure Black theme"
                       >
                         <motion.div 
                           animate={{ x: settings.pureBlack ? 24 : 4 }}
@@ -308,7 +327,7 @@ export function SettingsModal({ isOpen, onClose }: { isOpen: boolean; onClose: (
                   onClick={() => setIsAddModalOpen(true)}
                   className="w-full flex items-center justify-center gap-2 p-4 rounded-2xl bg-indigo-100 dark:bg-indigo-900/30 text-indigo-900 dark:text-indigo-100 hover:bg-indigo-200 dark:hover:bg-indigo-900/50 transition-colors font-medium"
                 >
-                  <Plus className="w-5 h-5" />
+                  <Plus className="w-5 h-5" aria-hidden="true" />
                   Add New Feed or Import OPML
                 </button>
               </section>


### PR DESCRIPTION
🎨 Palette: Enhance onboarding and modal accessibility

This PR implements a micro-UX improvement to guide new users through their first feed setup and significantly improves the accessibility of the application's modals.

### Key Changes:
1.  **Onboarding CTA**: When the app has no configured feeds, a prominent "Add your first feed" button is now displayed in the empty state. This button deep-links the user directly to the Subscriptions tab within the Settings modal.
2.  **Modal Tab Deep-linking**: Modified `SettingsModal.tsx` to accept an `initialTab` prop, allowing contextual entry into specific settings sections.
3.  **Accessibility Overhaul**:
    *   Added `aria-label="Go back"` and `aria-label="Close settings"` to the modal header buttons.
    *   Improved the "Pure Black" toggle with `role="switch"` and `aria-checked` for proper screen reader announcement.
    *   Added `aria-label="Feed URL"` to the input in `AddFeedModal.tsx`.
    *   Ensured all decorative Lucide icons are marked with `aria-hidden="true"`.

### Verification:
- **Visual**: Screenshots captured via Playwright confirm the new CTA button and deep-linking functionality.
- **Lint**: `pnpm lint` passed.
- **Build**: `pnpm build` completed successfully.
- **Manual**: Verified that `pnpm-lock.yaml` and `package.json` remain unchanged from their original state (reverting accidental changes during dependency installation).

📸 Screenshots available in `/home/jules/verification/empty_state.png` and `/home/jules/verification/settings_subscriptions.png`.

---
*PR created automatically by Jules for task [17739479173810555349](https://jules.google.com/task/17739479173810555349) started by @malamoffo*