### PR TITLE
Potential fix for code scanning alert no. 28: Incomplete URL substring sanitization

### DIFF
--- a/src/services/storage/reddit.ts
+++ b/src/services/storage/reddit.ts
@@ -4,6 +4,15 @@ import { fetchWithProxy } from '../../utils/proxy';
 import he from 'he';
 
 export const redditStorage = {
+  isImgurUrl(url: string): boolean {
+    try {
+      const { hostname } = new URL(url);
+      return hostname === 'imgur.com' || hostname.endsWith('.imgur.com');
+    } catch {
+      return false;
+    }
+  },
+
   async fetchJsonWithProxy(url: string, signal?: AbortSignal, etag?: string, lastModified?: string): Promise<{ data: any, etag?: string, lastModified?: string } | null> {
     const response = await fetchWithProxy(url, false, undefined, signal, etag, lastModified);
     
@@ -216,7 +225,7 @@ export const redditStorage = {
         if (post.preview && post.preview.images && post.preview.images.length > 0) {
           const preview = post.preview.images[0];
           imageUrl = preview.source.url;
-        } else if (post.url && (post.url.match(/\.(jpg|jpeg|png|gif|webp)$/) || post.url.includes('imgur.com'))) {
+        } else if (post.url && (post.url.match(/\.(jpg|jpeg|png|gif|webp)$/) || this.isImgurUrl(post.url))) {
           imageUrl = post.url;
         } else if (post.thumbnail && post.thumbnail.startsWith('http')) {
           imageUrl = post.thumbnail;


### PR DESCRIPTION
Potential fix for [https://github.com/malamoffo/flusso/security/code-scanning/28](https://github.com/malamoffo/flusso/security/code-scanning/28)

Use URL parsing and hostname validation instead of substring matching.

Best fix in this file:
- In `src/services/storage/reddit.ts`, within `fetchRedditPosts` where `imageUrl` is selected (around line 219), replace `post.url.includes('imgur.com')` with a safe hostname check.
- Parse `post.url` with `new URL(post.url)` in a small helper method in `redditStorage`.
- Accept only `imgur.com` and proper subdomains (for example `i.imgur.com`) by checking:
  - `hostname === 'imgur.com'` OR
  - `hostname.endsWith('.imgur.com')`
- Guard parsing with `try/catch` so invalid URLs return `false` and preserve existing behavior.

No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
