### PR TITLE
Potential fix for code scanning alert no. 27: Incomplete URL substring sanitization

### DIFF
--- a/src/services/storage/reddit.ts
+++ b/src/services/storage/reddit.ts
@@ -4,6 +4,15 @@ import { fetchWithProxy } from '../../utils/proxy';
 import he from 'he';
 
 export const redditStorage = {
+  isImgurUrl(url: string): boolean {
+    try {
+      const hostname = new URL(url).hostname.toLowerCase();
+      return hostname === 'imgur.com' || hostname.endsWith('.imgur.com');
+    } catch {
+      return false;
+    }
+  },
+
   async fetchJsonWithProxy(url: string, signal?: AbortSignal, etag?: string, lastModified?: string): Promise<{ data: any, etag?: string, lastModified?: string } | null> {
     const response = await fetchWithProxy(url, false, undefined, signal, etag, lastModified);
     
@@ -150,7 +159,7 @@ export const redditStorage = {
         if (post.preview && post.preview.images && post.preview.images.length > 0) {
           const preview = post.preview.images[0];
           imageUrl = preview.source.url;
-        } else if (post.url && (post.url.match(/\.(jpg|jpeg|png|gif|webp)$/) || post.url.includes('imgur.com'))) {
+        } else if (post.url && (post.url.match(/\.(jpg|jpeg|png|gif|webp)$/) || this.isImgurUrl(post.url))) {
           imageUrl = post.url;
         } else if (post.thumbnail && post.thumbnail.startsWith('http')) {
           imageUrl = post.thumbnail;


### PR DESCRIPTION
Potential fix for [https://github.com/malamoffo/flusso/security/code-scanning/27](https://github.com/malamoffo/flusso/security/code-scanning/27)

Use URL parsing and hostname-based allowlisting instead of substring matching on the whole URL.

Best fix in this file: replace `post.url.includes('imgur.com')` with logic that:
1. Safely parses `post.url` using `new URL(...)` (inside a small helper).
2. Extracts `hostname` and normalizes to lowercase.
3. Accepts only exact `imgur.com` or a true subdomain (`*.imgur.com`), not arbitrary strings containing `imgur.com`.

This preserves existing functionality (accepting imgur links) while preventing accidental matches from path/query or deceptive hostnames.  
Edits are only needed in `src/services/storage/reddit.ts` around the image URL selection block and by adding a small helper method inside `redditStorage`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
